### PR TITLE
fix(backup): use cross-platform safe timestamp for backup IDs

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -28,9 +28,9 @@ export interface BackupInfo {
 function generateBackupId(): string {
     const now = new Date()
     const pad = (n: number) => n.toString().padStart(2, '0')
-    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(
+    return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(
         now.getDate(),
-    )}-${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+    )}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
 }
 
 function getBackupCacheDir(config: IConfig): string {


### PR DESCRIPTION
Switch backup ID timestamps to YYYYMMDD_HHmmss to avoid : and ensure compatibility on Windows while keeping the format compact and readable.
<img width="1069" height="56" alt="image" src="https://github.com/user-attachments/assets/1a70b355-0a5b-4127-a1a8-e05513d2103b" />
